### PR TITLE
.cabal: remove outdated conditionals

### DIFF
--- a/time-compat.cabal
+++ b/time-compat.cabal
@@ -106,9 +106,6 @@ test-suite instances
 -- * disabled 'TimeOfDay minBound 0 0' (Test.LocalTime.Time)
 --
 test-suite main
-  if !impl(ghc >=7.4)
-    buildable: False
-
   default-language:   Haskell2010
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test/main
@@ -140,11 +137,6 @@ test-suite main
     , tasty-quickcheck  >=0.11     && <0.12
     , template-haskell
     , time-compat
-
-  if !impl(ghc >=8.0)
-    build-depends:
-        fail        >=4.9.0.0 && <4.10
-      , semigroups  >=0.18.5  && <0.21
 
   build-depends:      time
   main-is:            Main.hs


### PR DESCRIPTION
Since `base >= 4.12` forces GHC 8.6 or higher, these conditionals can
never fire.
